### PR TITLE
fix: Try esentutl for registry extraction before fget

### DIFF
--- a/srudb_plugin.py
+++ b/srudb_plugin.py
@@ -1177,7 +1177,7 @@ def plugin_init(ese_database):
     if args and args[0].lower() == "live":
         live_path = pathlib.Path("c:\\Windows\\System32\\Config\\SOFTWARE")
         if live_path.exists():
-            regpath = extract_live_file(live_path)
+            regpath = extract_live_ese(live_path)
             wireless_lookup = load_interfaces(str(regpath))
             registry_sids = load_registry_sids(str(regpath))
         else:


### PR DESCRIPTION
When trying to run a command like:

> .\ese2csv.exe -p srudb_plugin -a --plugin-args LIVE -l -- C:\Windows\System32\sru\SRUDB.dat

On my Windows 10 1909 system, I get an error:

> ERROR running FGET.EXE: b'-= FGET v1.0 - Forensic Data Acquisition Utility - (c)HBGary, Inc 2010 =-\r\r\n[+] MISMATCH Of FileRecord->numberOfMFT: 0 and FileIndex: 6\r\r\nCould not initialize the in-use cluster bitmap.\r\n'

This PR changes the srudb_plugin to use `esentutl.exe` in preference to `fget.exe` for the registry extraction, which solves the problem for me.